### PR TITLE
Build system: Adjust the build system for the new file system.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "default-assets"]
+	path = default-assets
+	url = https://github.com/GrangerHub/tremulous-default-assets.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ matrix:
     env: PLATFORM=linux
     before_install:
     - docker pull grangerhub/tremulous13:latest
-    - docker run -e PLATFORM -v $(pwd):/usr/src grangerhub/tremulous13:latest ./misc/docker-build.sh
+    - docker run -e PLATFORM -v $(pwd):/usr/src grangerhub/tremulous13:latest ./misc/travis-ci-docker-build.sh
     script:
     - true
   - os: linux
     env: PLATFORM=mingw32
     before_install:
     - docker pull grangerhub/tremulous13:latest
-    - docker run -e PLATFORM -v $(pwd):/usr/src grangerhub/tremulous13:latest ./misc/docker-build.sh
+    - docker run -e PLATFORM -v $(pwd):/usr/src grangerhub/tremulous13:latest ./misc/travis-ci-docker-build.sh
     script:
     - true
   - os: linux
@@ -34,7 +34,7 @@ matrix:
     before_install:
     - docker pull grangerhub/tremulous13:latest
     - docker run -e ARCH -e PLATFORM -v $(pwd):/usr/src grangerhub/tremulous13:latest
-      ./misc/docker-build.sh
+      ./misc/travis-ci-docker-build.sh
     script:
     - true
   - os: osx
@@ -49,9 +49,9 @@ deploy:
   provider: releases
   skip_cleanup: true
   api_key:
-    secure: "jtNUkZL1TK3nD1LfWi5kypaL2WzUHxM/N72AcwKTmvieQ/3iwL8gRDFOhfWKFkNcyuCsEBw+c2KlpgfNGVNZYJgZrQ3Ozvnno5yN+V8Pb4ODEFU0Ps4EHSY7gsdF6bBdp3ooqsCsg8BkGfIggFsV+R9oKOyWWH1/N1jPWhf8ioWD+mMaAh5ZOsyQIECtSKAKMu9/hikVkdDuNsIAiaiJhYvP8rli5fYrZ4sVJih3YgeJj42i2iLeeWXmOmYNF7T5ywuBpaUjQJBEo83MilglTF0UOb471ADU2Gz3SMrnNCOdqDZLQaBL+QVrrgJUvXy5A92nxkY16mJaIvdDEOeIzWwgWVLoKyil6AFW5bR7lp2YW+/4I6zYEkGrpUaiZ+S1lgvm3CwVgwhg3rVuCi0qrI/7j/ImS9ORmz9DGbVgtg+y7mZnUIcEWX4jRDbbYWYIc/1fN+fGt73+41h0HS5of7d31yH6AyxB8/DlkuoKZIVHiErD0J3ZUkdVJOwhPFiPKViYR/07KEvafhkZkcffZh7arIesFB++4Kmglapb/awHJRh4lhfKd16IiCGjjfof8MDKSkmqAdXUsdCRcPu1Q0/cJaO3TRiTS6M0skrBUeIOOYsV0AdWM1Fy7dTySEEYlqZXnkiD98MG7CwobkWXmeVZHEzOJh2fDtv2w2ojoDI="
+    secure: g9HIz82c3vz3bl7vsMuODCz6kwf4IogJGw8V1Pn7TapXTeO9JnR1BqAhQbuqjPEBsgnIf+zwNblzBYmSyihB5I8JC8GiyhX/5tq5C/fd0z+uAH3Gsm5BFowRRUjVQlneH61NY4LP8H6h1KfkFBlD3NfW1D8kCa7vUyEh4Lj11wJMj9WgYctYfPu0rW2f8mCBSJ5VPR0EDNnJ8DV0EKEKmv7tiF6sY6eLuMg7VMtSPCCd/NkSQz1A04xYi6AwghrCJ8EZvkBhRIqgUGFL8y2si2Dt30fEG4nz4eDuqm17JoI9NX6Iz7v8iwU2CBL4wrDlqVYcncYxFqL89ZcXAmVHBl9eqqPKfA0KzR10IbkjVuVGvM0eQTOlGayDNalutZ0UtDuqPnMjHALpH+AsGUCwdYCQN5KL6b/xsgmQYUHuRE2ThbVk6MC7UbVSj6BQPiff9q41lSlHin2tkL9XUrGea0RY9d8F5dgT1oiYygUOpXcXA8slme2zvkuaNDrgFgkqU9ii3zqhqJxcFHkDIOmqxJJhyKcI4v6BWCz0evZzV4Qv3LpQyZeKJhmCAH5yU3xJYwV5ePoHrEeZc4a9y46V6R2hMttwawyR1TPZeT4PvEAFtusmfpmVeVlLhB9mmINK/D9LmuTEo0CdBioCgsIM1YQLFT8727yC/acB61dYowE=
   file_glob: true
   file: build/*.zip
   on:
-    repo: GrangerHub/tremulous
+    repo: dGr8LookinSparky/tremulous
     tags: true

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ You can install the latest released binaries from GrangerHub's release page,
 following these steps:
 
 * Download the most recent .zip file for your platform from https://github.com/GrangerHub/tremulous/releases
- - The 64 bit Windows release would be named release-mingw32-x86_64.zip
- - The 64 bit Linux release would be named release-linux-x86_64.zip
- - The 64 bit Mac OS X release would be named release-darwin-x86_64.zip
+ - The 64 bit Windows release would be named release-windows-64.zip
+ - The 32 bit Windows release would be named release-windows-32.zip
+ - The 64 bit Linux release would be named release-linux-64.zip
+ - The 64 bit Mac OS X release would be named release-macos-64.zip
 * Unzip the release .zip anywhere
 * Run the tremulous.exe from the unzipped release directory.
  - When you run the tremulous.exe binary for the first time, it may go through a bootstrap (download needed assets, generate an RSA key) process which may take a few minutes.
@@ -65,8 +66,8 @@ For Linux and Mac OS X builds, follow these steps.
 git clone https://github.com/GrangerHub/tremulous.git
 cd tremulous
 make
-# cd build/release-darwin-x86_64/
-# cd build/release-linux-x86_64/
+# cd build/release-macos-64/
+# cd build/release-linux-64/
 ./tremulous
 ```
 

--- a/external/nettle-3.3/CMakeLists.txt
+++ b/external/nettle-3.3/CMakeLists.txt
@@ -34,5 +34,4 @@ include_directories (
     include
     )
 
-# command: /usr/bin/clang -Wall -Wextra -DLUA_COMPAT_5_2 -fPIC -fpic -o build/release-darwin-x86_64/nettle/bignum.o -c src/nettle-3.3/nettle/bignum.c
-
+# command: /usr/bin/clang -Wall -Wextra -DLUA_COMPAT_5_2 -fPIC -fpic -o build/release-macos-64/nettle/bignum.o -c src/nettle-3.3/nettle/bignum.c

--- a/make-macosx-app.sh
+++ b/make-macosx-app.sh
@@ -127,11 +127,17 @@ IOQ3_MP_CGAME_ARCHS=""
 IOQ3_MP_GAME_ARCHS=""
 IOQ3_MP_UI_ARCHS=""
 
-BASEDIR="gpp"
+BASEDIR="trem13"
 
-CGAME="cgame"
-GAME="game"
-UI="ui"
+if [[ "${TARGET_NAME}" == "release" ]]; then
+	CGAME="core-cgame"
+	GAME="core-game"
+	UI="core-ui"
+else
+	CGAME="cgame"
+	GAME="game"
+	UI="ui"
+fi
 
 RENDERER_OPENGL="renderer_opengl"
 
@@ -142,7 +148,8 @@ GAME_NAME="${GAME}.dylib"
 UI_NAME="${UI}.dylib"
 
 GIT_REV=$(git describe --tags)
-VMS_PK3="vms-${GIT_REV}.pk3"
+VMS_GPP_PK3="vms-gpp-${GIT_REV}.pk3"
+VMS_11_PK3="vms-1.1-${GIT_REV}.pk3"
 DATA_PK3="data-${GIT_REV}.pk3"
 
 RENDERER_OPENGL1_NAME="${RENDERER_OPENGL}1.dylib"
@@ -153,7 +160,7 @@ ICNS="Tremulous.icns"
 PKGINFO="APPLIOQ3"
 
 OBJROOT="build"
-#BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-darwin-${CURRENT_ARCH}"
+#BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-${CURRENT_ARCH}"
 PRODUCT_NAME="Tremulous"
 WRAPPER_EXTENSION="app"
 WRAPPER_NAME="${PRODUCT_NAME}.${WRAPPER_EXTENSION}"
@@ -165,7 +172,13 @@ EXECUTABLE_NAME="tremulous"
 # loop through the architectures to build string lists for each universal binary
 for ARCH in $SEARCH_ARCHS; do
 	CURRENT_ARCH=${ARCH}
-	BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-darwin-${CURRENT_ARCH}"
+	if [ "${CURRENT_ARCH}" == "x86_64" ]; then
+		BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-64"
+	elif [[ "${CURRENT_ARCH}" == "x86" ]]; then
+		BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-32"
+	else
+		BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-${CURRENT_ARCH}"
+	fi
 	IOQ3_CLIENT="${EXECUTABLE_NAME}"
 	IOQ3_SERVER="${DEDICATED_NAME}"
 	IOQ3_RENDERER_GL1="${RENDERER_OPENGL}1.dylib"
@@ -228,12 +241,19 @@ fi
 
 # set the final application bundle output directory
 if [ "${2}" == "" ]; then
-	BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-darwin-universal"
+	BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-universal"
 	if [ ! -d ${BUILT_PRODUCTS_DIR} ]; then
 		mkdir -p ${BUILT_PRODUCTS_DIR} || exit 1;
 	fi
 else
-	BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-darwin-${CURRENT_ARCH}"
+	if [ "${CURRENT_ARCH}" == "x86_64" ]; then
+		BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-64"
+	elif [[ "${CURRENT_ARCH}" == "x86" ]]; then
+		BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-32"
+	else
+		BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-${CURRENT_ARCH}"
+	fi
+		#statements
 fi
 
 BUNDLEBINDIR="${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}"
@@ -251,6 +271,12 @@ echo ""
 if [ ! -d ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/$BASEDIR ]; then
 	mkdir -p ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/$BASEDIR || exit 1;
 fi
+if [ ! -d ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/gpp ]; then
+	mkdir -p ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/gpp || exit 1;
+fi
+if [ ! -d ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/base ]; then
+	mkdir -p ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}/base || exit 1;
+fi
 if [ ! -d ${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH} ]; then
 	mkdir -p ${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH} || exit 1;
 fi
@@ -258,7 +284,8 @@ fi
 # copy and generate some application bundle resources
 cp external/libs/macosx/*.dylib ${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}
 cp ${ICNSDIR}/${ICNS} ${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/$ICNS || exit 1;
-cp	"${BUILT_PRODUCTS_DIR}/${BASEDIR}/${VMS_PK3}" "${BUNDLEBINDIR}/${BASEDIR}/${VMS_PK3}"
+cp	"${BUILT_PRODUCTS_DIR}/${BASEDIR}/${VMS_GPP_PK3}" "${BUNDLEBINDIR}/${BASEDIR}/${VMS_GPP_PK3}"
+cp	"${BUILT_PRODUCTS_DIR}/${BASEDIR}/${VMS_11_PK3}" "${BUNDLEBINDIR}/${BASEDIR}/${VMS_11_PK3}"
 cp	"${BUILT_PRODUCTS_DIR}/${BASEDIR}/${DATA_PK3}" "${BUNDLEBINDIR}/${BASEDIR}/${DATA_PK3}"
 echo -n ${PKGINFO} > ${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/PkgInfo || exit 1;
 echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
@@ -290,7 +317,7 @@ echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
     <key>LSMinimumSystemVersion</key>
     <string>${MACOSX_DEPLOYMENT_TARGET}</string>
     <key>NSHumanReadableCopyright</key>
-    <string>Copyright © 1999-2015 Id Software LLC, a ZeniMax Media company, ioquake3, Darklegion Development, GrangerHub, and Tremulous community contributors.</string>
+    <string>Copyright © 1999-2020 Id Software LLC, a ZeniMax Media company, ioquake3, Darklegion Development, GrangerHub, and Tremulous community contributors.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
 </dict>

--- a/misc/make-macosx-ub.sh
+++ b/misc/make-macosx-ub.sh
@@ -67,24 +67,24 @@ fi
 NCPU=`sysctl -n hw.ncpu`
 
 # x86_64 client and server
-#if [ -d build/release-release-x86_64 ]; then
-#	rm -r build/release-darwin-x86_64
+#if [ -d build/release-macos-64 ]; then
+#	rm -r build/release-macos-64
 #fi
 (ARCH=x86_64 CC=gcc-4.0 CFLAGS=$X86_64_CFLAGS LDFLAGS=$X86_64_LDFLAGS make -j$NCPU) || exit 1;
 
 echo;echo
 
 # x86 client and server
-#if [ -d build/release-darwin-x86 ]; then
-#	rm -r build/release-darwin-x86
+#if [ -d build/release-macos-32 ]; then
+#	rm -r build/release-macos-32
 #fi
 (ARCH=x86 CC=gcc-4.0 CFLAGS=$X86_CFLAGS LDFLAGS=$X86_LDFLAGS make -j$NCPU) || exit 1;
 
 echo;echo
 
 # PPC client and server
-#if [ -d build/release-darwin-ppc ]; then
-#	rm -r build/release-darwin-ppc
+#if [ -d build/release-macos-ppc ]; then
+#	rm -r build/release-macos-ppc
 #fi
 (ARCH=ppc CC=gcc-4.0 CFLAGS=$PPC_CFLAGS LDFLAGS=$PPC_LDFLAGS make -j$NCPU) || exit 1;
 

--- a/misc/make-macosx.sh
+++ b/misc/make-macosx.sh
@@ -30,7 +30,14 @@ if [ -z "$DARWIN_GCC_ARCH" ]; then
 fi
 
 CC=gcc-4.0
-DESTDIR=build/release-darwin-${BUILDARCH}
+if [ "${BUILDARCH}" == "x86_64" ]; then
+	DESTDIR=build/release-macos-64
+elif [[ "${BUILDARCH}" == "x86" ]]; then
+	DESTDIR=build/release-macos-32
+else
+	DESTDIR=build/release-macos-${BUILDARCH}
+fi
+	#statements
 
 cd `dirname $0`
 if [ ! -f Makefile ]; then
@@ -68,8 +75,8 @@ NCPU=`sysctl -n hw.ncpu`
 
 
 # intel client and server
-#if [ -d build/release-darwin-${BUILDARCH} ]; then
-#	rm -r build/release-darwin-${BUILDARCH}
+#if [ -d build/release-macos-${BUILDARCH} ]; then
+#	rm -r build/release-macos-${BUILDARCH}
 #fi
 (ARCH=${BUILDARCH} CFLAGS=$ARCH_CFLAGS LDFLAGS=$ARCH_LDFLAGS make -j$NCPU) || exit 1;
 

--- a/misc/travis-ci-build.sh
+++ b/misc/travis-ci-build.sh
@@ -16,4 +16,3 @@ else
 fi
 
 exit $failed
-

--- a/misc/travis-ci-docker-build.sh
+++ b/misc/travis-ci-docker-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+failed=0
+
+USE_RESTCLIENT=1 USE_INTERNAL_LUA=1 make -j 2 || failed=1
+
+if [[ $failed -eq 1 ]]; then
+    echo "Build failure."
+    exit $failed
+fi
+
+./misc/download-paks.sh
+chmod -R ugo+rw build

--- a/src/qcommon/q_platform.h
+++ b/src/qcommon/q_platform.h
@@ -105,8 +105,15 @@ extern "C" {
     
     #if defined( __WIN64__ ) 
     #define ARCH_STRING "x86_64"
+    #define READABLE_ARCH_STRING "64"
+    #elif defined( __WIN32__ )
+    #define ARCH_STRING "x86"
+    #define READABLE_ARCH_STRING "32"
     #elif defined _M_ALPHA
     #define ARCH_STRING "AXP"
+    #define READABLE_ARCH_STRING ARCH_STRING
+    #else
+    #define READABLE_ARCH_STRING ARCH_STRING
     #endif
     
     #define Q3_LITTLE_ENDIAN
@@ -115,8 +122,8 @@ extern "C" {
     #define EXE_EXT ".exe"
 
     // For cl_updates.cpp
-    #define RELEASE_PACKAGE_NAME ( "release-mingw32-" ARCH_STRING ".zip" )
-    #define RELEASE_SIGNATURE_NAME ( "release-mingw32-" ARCH_STRING ".zip.sig" )
+    #define RELEASE_PACKAGE_NAME ( "release-windows-" READABLE_ARCH_STRING ".zip" )
+    #define RELEASE_SIGNATURE_NAME ( "release-windows-" READABLE_ARCH_STRING ".zip.sig" )
     #define GRANGER_EXE ( "granger" EXE_EXT )
 
 #elif defined(_WIN32) || defined(__WIN32__)
@@ -138,8 +145,15 @@ extern "C" {
     
     #if defined( _M_IX86 ) || defined( __i386__ )
     #define ARCH_STRING "x86"
+    #define READABLE_ARCH_STRING "32"
+    #elif defined _M_X64
+    #define ARCH_STRING "x86_64"
+    #define READABLE_ARCH_STRING "64"
     #elif defined _M_ALPHA
     #define ARCH_STRING "AXP"
+    #define READABLE_ARCH_STRING ARCH_STRING
+    #else
+    #define READABLE_ARCH_STRING ARCH_STRING
     #endif
     
     #define Q3_LITTLE_ENDIAN
@@ -148,8 +162,8 @@ extern "C" {
     #define EXE_EXT ".exe"
 
     // For cl_updates.cpp
-    #define RELEASE_PACKAGE_NAME ( "release-mingw32-" ARCH_STRING ".zip" )
-    #define RELEASE_SIGNATURE_NAME ( "release-mingw32-" ARCH_STRING ".zip.sig" )
+    #define RELEASE_PACKAGE_NAME ( "release-windows-" READABLE_ARCH_STRING ".zip" )
+    #define RELEASE_SIGNATURE_NAME ( "release-windows-" READABLE_ARCH_STRING ".zip.sig" )
     #define GRANGER_EXE ( "granger" EXE_EXT )
 
 #endif
@@ -165,23 +179,28 @@ extern "C" {
 
     #ifdef __ppc__
     #define ARCH_STRING "ppc"
+    #define READABLE_ARCH_STRING ARCH_STRING
     #define Q3_BIG_ENDIAN
     #elif defined __i386__
     #define ARCH_STRING "x86"
+    #define READABLE_ARCH_STRING "32"
     #define Q3_LITTLE_ENDIAN
     #elif defined __x86_64__
     #undef idx64
     #define idx64 1
     #define ARCH_STRING "x86_64"
+    #define READABLE_ARCH_STRING "64"
     #define Q3_LITTLE_ENDIAN
+    #else
+    #define READABLE_ARCH_STRING ARCH_STRING
     #endif
 
     #define DLL_EXT ".dylib"
     #define EXE_EXT
 
     // For cl_updates.cpp
-    #define RELEASE_PACKAGE_NAME ( "release-darwin-" ARCH_STRING ".zip" )
-    #define RELEASE_SIGNATURE_NAME ( "release-darwin-" ARCH_STRING ".zip.sig" )
+    #define RELEASE_PACKAGE_NAME ( "release-macos-" READABLE_ARCH_STRING ".zip" )
+    #define RELEASE_SIGNATURE_NAME ( "release-macos-" READABLE_ARCH_STRING ".zip.sig" )
     #define GRANGER_EXE ( "granger" EXE_EXT )
 
 #endif
@@ -206,12 +225,15 @@ extern "C" {
     
     #ifdef __ppc__
      #define ARCH_STRING "ppc"
+     #define READABLE_ARCH_STRING ARCH_STRING
      #define Q3_BIG_ENDIAN
     #elif defined __i386__
      # define ARCH_STRING "x86"
+     # define READABLE_ARCH_STRING "32"
      # define Q3_LITTLE_ENDIAN
     #elif defined __x86_64__
      # define ARCH_STRING "x86_64"
+     # define READABLE_ARCH_STRING "64"
      # define Q3_LITTLE_ENDIAN
      #undef idx64
      #define idx64 1
@@ -221,9 +243,11 @@ extern "C" {
      # endif
      # if defined __armhf__
       # define ARCH_STRING "armhf"
+      #define READABLE_ARCH_STRING ARCH_STRING
       # define Q3_LITTLE_ENDIAN
      # else
       # define ARCH_STRING "armel"
+      #define READABLE_ARCH_STRING ARCH_STRING
       # define Q3_LITTLE_ENDIAN
      # endif
     #elif defined __aarch64__
@@ -231,15 +255,18 @@ extern "C" {
       # error "Big endian ARM is not supported"
      # endif
      # define ARCH_STRING "aarch64"
+     #define READABLE_ARCH_STRING ARCH_STRING
      # define Q3_LITTLE_ENDIAN
+     #else
+     #define READABLE_ARCH_STRING ARCH_STRING
     #endif
     
     #define DLL_EXT ".so"
     #define EXE_EXT
     
     // For cl_updates.cpp
-    #define RELEASE_PACKAGE_NAME ( "release-linux-" ARCH_STRING ".zip" )
-    #define RELEASE_SIGNATURE_NAME ( "release-linux-" ARCH_STRING ".zip.sig" )
+    #define RELEASE_PACKAGE_NAME ( "release-linux-" READABLE_ARCH_STRING ".zip" )
+    #define RELEASE_SIGNATURE_NAME ( "release-linux-" READABLE_ARCH_STRING ".zip.sig" )
     #define GRANGER_EXE ( "granger" EXE_EXT )
  
 #endif


### PR DESCRIPTION
- Change the basegame to trem13.
- Add the prefix "core-" to dynamic libraries only in release builds.
- Have the game logic modules and packaged pk3 files build in the basemod folder for only in debug builds.
- Download the default assets from the tremulous-default-assets repo.
- Don't build the QVMs and don't package the assets for builds by travis-ci, so that only default assets are distributed in github releases.
- Add a submodule for the default assets to prevent unnecessary downloading for local builds.
- Change the operating system and archeture names of the releases to clearer and more recognizable names to the general public.