### PR TITLE
- change the naming of the core-cgame and core-ui dynamic libraries b…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,10 @@ endif
 
 BASEGAME_CFLAGS=-I../../${MOUNT_DIR}
 
+ifndef BASEMOD
+BASEMOD=basemod
+endif
+
 ifndef COPYDIR
 COPYDIR="/usr/local/games/tremulous"
 endif
@@ -848,57 +852,37 @@ ifneq ($(BUILD_CLIENT),0)
 endif
 
 ifneq ($(BUILD_GAME_SO),0)
-ifeq ($(B),$(BR))
-  TARGETS += \
-    $(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-    $(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-    $(B)/$(BASEGAME)/core-ui$(SHLIBNAME)
+ifneq ($(BASEMOD), basemod)
+TARGETS += \
+  $(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+  $(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+  $(B)/$(BASEMOD)/ui$(SHLIBNAME)
 else
 TARGETS += \
-  $(B)/basemod/cgame$(SHLIBNAME) \
-  $(B)/basemod/game$(SHLIBNAME) \
-  $(B)/basemod/ui$(SHLIBNAME)
+  $(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+  $(B)/$(BASEMOD)/game$(SHLIBNAME) \
+  $(B)/$(BASEMOD)/ui$(SHLIBNAME)
 endif
 endif
 
 ifneq ($(BUILD_GAME_QVM),0)
-ifeq ($(B),$(BR))
-  TARGETS += \
-    $(B)/$(BASEGAME)/vm/cgame.qvm \
-    $(B)/$(BASEGAME)/vm/game.qvm \
-    $(B)/$(BASEGAME)/vm/ui.qvm \
-	$(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3
-else
-  TARGETS += \
-    $(B)/basemod/vm/cgame.qvm \
-    $(B)/basemod/vm/game.qvm \
-    $(B)/basemod/vm/ui.qvm \
-    $(B)/basemod/vms-gpp-$(VERSION).pk3
-endif
+TARGETS += \
+  $(B)/$(BASEMOD)/vm/cgame.qvm \
+  $(B)/$(BASEMOD)/vm/game.qvm \
+  $(B)/$(BASEMOD)/vm/ui.qvm \
+  $(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3
 endif
 
 ifneq ($(BUILD_GAME_QVM_11),0)
-ifeq ($(B),$(BR))
-  TARGETS += \
-    $(B)/$(BASEGAME)_11/vm/cgame.qvm \
-    $(B)/$(BASEGAME)_11/vm/ui.qvm \
-    $(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3
-else
-  TARGETS += \
-    $(B)/$(BASEGAME)_11/vm/cgame.qvm \
-    $(B)/$(BASEGAME)_11/vm/ui.qvm \
-    $(B)/basemod/vms-1.1-$(VERSION).pk3
-endif
+TARGETS += \
+  $(B)/$(BASEMOD)_11/vm/cgame.qvm \
+  $(B)/$(BASEMOD)_11/vm/ui.qvm \
+  $(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3
 endif
 
 ifneq ($(BUILD_DATA_PK3),0)
-ifeq ($(B),$(BR))
-  TARGETS += \
-    $(B)/$(BASEGAME)/data-$(VERSION).pk3
-else
-  TARGETS += \
-    $(B)/basemod/data-$(VERSION).pk3
-endif
+TARGETS += \
+  $(B)/$(BASEMOD)/data-$(VERSION).pk3
 endif
 
 ifneq ($(NEW_FILESYSTEM),0)
@@ -1302,7 +1286,7 @@ endif
 
 $(B).zip: $(TARGETS)
 ifeq ($(PLATFORM),darwin)
-	@("./make-macosx-app.sh" release $(ARCH); if [ "$$?" -eq 0 ] && [ -d "$(B)/Tremulous.app" ]; then rm -f $@; cd $(B) && zip --symlinks -r9 ../../$@ GPL COPYING CC `find "Tremulous.app" -print | sed -e "s!$(B)/!!g"`; else rm -f $@; cd $(B) && zip -r9 ../../$@ $(NAKED_TARGETS); fi)
+	@("./make-macosx-app.sh" release $(BASEMOD) $(ARCH); if [ "$$?" -eq 0 ] && [ -d "$(B)/Tremulous.app" ]; then rm -f $@; cd $(B) && zip --symlinks -r9 ../../$@ GPL COPYING CC `find "Tremulous.app" -print | sed -e "s!$(B)/!!g"`; else rm -f $@; cd $(B) && zip -r9 ../../$@ $(NAKED_TARGETS); fi)
 else
 	@rm -f $@
 	@(cd $(B) && zip -r9 ../../$@ $(NAKED_TARGETS))
@@ -1334,9 +1318,9 @@ makedirs:
 	@if [ ! -d $(B)/$(BASEGAME)/11/cgame ];then $(MKDIR) $(B)/$(BASEGAME)/11/cgame;fi
 	@if [ ! -d $(B)/$(BASEGAME)/11/ui ];then $(MKDIR) $(B)/$(BASEGAME)/11/ui;fi
 	@if [ ! -d $(B)/$(BASEGAME)/vm ];then $(MKDIR) $(B)/$(BASEGAME)/vm;fi
-	@if [ ! -d $(B)/$(BASEGAME)_11 ];then $(MKDIR) $(B)/$(BASEGAME)_11;fi
-	@if [ ! -d $(B)/$(BASEGAME)_11/vm ];then $(MKDIR) $(B)/$(BASEGAME)_11/vm;fi
-	@if [ ! -d $(B)/basemod ];then $(MKDIR) $(B)/basemod;fi
+	@if [ ! -d $(B)/$(BASEMOD)_11 ];then $(MKDIR) $(B)/$(BASEMOD)_11;fi
+	@if [ ! -d $(B)/$(BASEMOD)_11/vm ];then $(MKDIR) $(B)/$(BASEMOD)_11/vm;fi
+	@if [ ! -d $(B)/$(BASEMOD) ];then $(MKDIR) $(B)/$(BASEMOD);fi
 	@if [ ! -d $(B)/granger.dir ];then $(MKDIR) $(B)/granger.dir;fi
 	@if [ ! -d $(B)/granger.dir/src ];then $(MKDIR) $(B)/granger.dir/src;fi
 	@if [ ! -d $(B)/granger.dir/src/lua ];then $(MKDIR) $(B)/granger.dir/src/lua;fi
@@ -2573,24 +2557,13 @@ CGOBJ_ = \
 CGOBJ = $(CGOBJ_) $(B)/$(BASEGAME)/cgame/cg_syscalls.o
 CGVMOBJ = $(CGOBJ_:%.o=%.asm)
 
-ifeq ($(B), $(BR))
-$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME): $(CGOBJ)
+$(B)/$(BASEMOD)/cgame$(SHLIBNAME): $(CGOBJ)
 	$(echo_cmd) "LD $@"
 	$(Q)$(CC) $(SHLIBLDFLAGS) $(LDFLAGS) -o $@ $(CGOBJ)
 
-$(B)/$(BASEGAME)/vm/cgame.qvm: $(CGVMOBJ) $(CGDIR)/cg_syscalls.asm $(Q3ASM)
+$(B)/$(BASEMOD)/vm/cgame.qvm: $(CGVMOBJ) $(CGDIR)/cg_syscalls.asm $(Q3ASM)
 	$(echo_cmd) "Q3ASM $@"
 	$(Q)$(Q3ASM) -o $@ $(CGVMOBJ) $(CGDIR)/cg_syscalls.asm
-
-else
-$(B)/basemod/cgame$(SHLIBNAME): $(CGOBJ)
-	$(echo_cmd) "LD $@"
-	$(Q)$(CC) $(SHLIBLDFLAGS) $(LDFLAGS) -o $@ $(CGOBJ)
-
-$(B)/basemod/vm/cgame.qvm: $(CGVMOBJ) $(CGDIR)/cg_syscalls.asm $(Q3ASM)
-	$(echo_cmd) "Q3ASM $@"
-	$(Q)$(Q3ASM) -o $@ $(CGVMOBJ) $(CGDIR)/cg_syscalls.asm
-endif
 
 #############################################################################
 ## TREMULOUS CGAME (1.1 COMPATIBLE)
@@ -2633,7 +2606,7 @@ CGOBJ11_ = \
 
 CGVMOBJ11 = $(CGOBJ11_:%.o=%.asm)
 
-$(B)/$(BASEGAME)_11/vm/cgame.qvm: $(CGVMOBJ11) $(CGDIR)/cg_syscalls_11.asm $(Q3ASM)
+$(B)/$(BASEMOD)_11/vm/cgame.qvm: $(CGVMOBJ11) $(CGDIR)/cg_syscalls_11.asm $(Q3ASM)
 	$(echo_cmd) "Q3ASM_11 $@"
 	$(Q)$(Q3ASM) -o $@ $(CGVMOBJ11) $(CGDIR)/cg_syscalls_11.asm
 
@@ -2678,24 +2651,19 @@ GOBJ_ = \
 GOBJ = $(GOBJ_) $(B)/$(BASEGAME)/game/g_syscalls.o
 GVMOBJ = $(GOBJ_:%.o=%.asm)
 
-ifeq ($(B), $(BR))
-$(B)/$(BASEGAME)/core-game$(SHLIBNAME): $(GOBJ)
+ifneq ($(BASEMOD), basemod)
+$(B)/$(BASEMOD)/core-game$(SHLIBNAME): $(GOBJ)
 	$(echo_cmd) "LD $@"
 	$(Q)$(CC) $(SHLIBLDFLAGS) $(LDFLAGS) -o $@ $(GOBJ)
-
-$(B)/$(BASEGAME)/vm/game.qvm: $(GVMOBJ) $(GDIR)/g_syscalls.asm $(Q3ASM)
-	$(echo_cmd) "Q3ASM $@"
-	$(Q)$(Q3ASM) -o $@ $(GVMOBJ) $(GDIR)/g_syscalls.asm
-
 else
-$(B)/basemod/game$(SHLIBNAME): $(GOBJ)
+$(B)/$(BASEMOD)/game$(SHLIBNAME): $(GOBJ)
 	$(echo_cmd) "LD $@"
 	$(Q)$(CC) $(SHLIBLDFLAGS) $(LDFLAGS) -o $@ $(GOBJ)
+endif
 
-$(B)/basemod/vm/game.qvm: $(GVMOBJ) $(GDIR)/g_syscalls.asm $(Q3ASM)
+$(B)/$(BASEMOD)/vm/game.qvm: $(GVMOBJ) $(GDIR)/g_syscalls.asm $(Q3ASM)
 	$(echo_cmd) "Q3ASM $@"
 	$(Q)$(Q3ASM) -o $@ $(GVMOBJ) $(GDIR)/g_syscalls.asm
-endif
 
 
 #############################################################################
@@ -2718,24 +2686,13 @@ UIOBJ_ = \
 UIOBJ = $(UIOBJ_) $(B)/$(BASEGAME)/ui/ui_syscalls.o
 UIVMOBJ = $(UIOBJ_:%.o=%.asm)
 
-ifeq ($(B), $(BR))
-$(B)/$(BASEGAME)/core-ui$(SHLIBNAME): $(UIOBJ)
+$(B)/$(BASEMOD)/ui$(SHLIBNAME): $(UIOBJ)
 	$(echo_cmd) "LD $@"
 	$(Q)$(CC) -I${ASSETS_DIR}/ui $(SHLIBLDFLAGS) $(LDFLAGS) -o $@ $(UIOBJ)
 
-$(B)/$(BASEGAME)/vm/ui.qvm: $(UIVMOBJ) $(UIDIR)/ui_syscalls.asm $(Q3ASM)
+$(B)/$(BASEMOD)/vm/ui.qvm: $(UIVMOBJ) $(UIDIR)/ui_syscalls.asm $(Q3ASM)
 	$(echo_cmd) "Q3ASM $@"
 	$(Q)$(Q3ASM) -o $@ $(UIVMOBJ) $(UIDIR)/ui_syscalls.asm
-
-else
-$(B)/basemod/ui$(SHLIBNAME): $(UIOBJ)
-	$(echo_cmd) "LD $@"
-	$(Q)$(CC) -I${ASSETS_DIR}/ui $(SHLIBLDFLAGS) $(LDFLAGS) -o $@ $(UIOBJ)
-
-$(B)/basemod/vm/ui.qvm: $(UIVMOBJ) $(UIDIR)/ui_syscalls.asm $(Q3ASM)
-	$(echo_cmd) "Q3ASM $@"
-	$(Q)$(Q3ASM) -o $@ $(UIVMOBJ) $(UIDIR)/ui_syscalls.asm
-endif
 
 $(B)/$(BASEGAME)/vm/ui.qvm: $(UIVMOBJ) $(UIDIR)/ui_syscalls.asm $(Q3ASM)
 	$(echo_cmd) "Q3ASM $@"
@@ -2761,7 +2718,7 @@ UIVMOBJ11 = $(UIOBJ11_:%.o=%.asm)
 
 # XXX no dynamic library?
 
-$(B)/$(BASEGAME)_11/vm/ui.qvm: $(UIVMOBJ11) $(UIDIR)/ui_syscalls_11.asm $(Q3ASM)
+$(B)/$(BASEMOD)_11/vm/ui.qvm: $(UIVMOBJ11) $(UIDIR)/ui_syscalls_11.asm $(Q3ASM)
 	$(echo_cmd) "Q3ASM $@"
 	$(Q)$(Q3ASM) -o $@ $(UIVMOBJ11) $(UIDIR)/ui_syscalls_11.asm
 
@@ -2769,24 +2726,13 @@ $(B)/$(BASEGAME)_11/vm/ui.qvm: $(UIVMOBJ11) $(UIDIR)/ui_syscalls_11.asm $(Q3ASM)
 ## QVM Package
 #############################################################################
 
-ifeq ($(B), $(BR))
 ifneq ($(BUILD_GAME_QVM),0)
-$(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3: $(B)/$(BASEGAME)/vm/ui.qvm $(B)/$(BASEGAME)/vm/cgame.qvm $(B)/$(BASEGAME)/vm/game.qvm
-	@(zip -r $(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3 $(B)/$(BASEGAME)/vm/)
+$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3: $(B)/$(BASEMOD)/vm/ui.qvm $(B)/$(BASEMOD)/vm/cgame.qvm $(B)/$(BASEMOD)/vm/game.qvm
+	@(zip -r $(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 $(B)/$(BASEMOD)/vm/)
 endif
 ifneq ($(BUILD_GAME_QVM_11),0)
-$(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3: $(B)/$(BASEGAME)_11/vm/ui.qvm $(B)/$(BASEGAME)_11/vm/cgame.qvm 
-	@(zip -r $(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3 $(B)/$(BASEGAME)_11/vm/)
-endif
-else
-ifneq ($(BUILD_GAME_QVM),0)
-$(B)/basemod/vms-gpp-$(VERSION).pk3: $(B)/basemod/vm/ui.qvm $(B)/basemod/vm/cgame.qvm $(B)/basemod/vm/game.qvm
-	@(zip -r $(B)/basemod/vms-gpp-$(VERSION).pk3 $(B)/basemod/vm/)
-endif
-ifneq ($(BUILD_GAME_QVM_11),0)
-$(B)/basemod/vms-1.1-$(VERSION).pk3: $(B)/$(BASEGAME)_11/vm/ui.qvm $(B)/$(BASEGAME)_11/vm/cgame.qvm 
-	@(zip -r $(B)/basemod/vms-1.1-$(VERSION).pk3 $(B)/$(BASEGAME)_11/vm/)
-endif
+$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3: $(B)/$(BASEMOD)_11/vm/ui.qvm $(B)/$(BASEMOD)_11/vm/cgame.qvm 
+	@(zip -r $(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 $(B)/$(BASEMOD)_11/vm/)
 endif
 
 
@@ -2795,16 +2741,9 @@ endif
 #############################################################################
 
 ifneq ($(BUILD_DATA_PK3),0)
-ifeq ($(B), $(BR))
-$(B)/$(BASEGAME)/data-$(VERSION).pk3: $(ASSETS_DIR)/ui/main.menu
+$(B)/$(BASEMOD)/data-$(VERSION).pk3: $(ASSETS_DIR)/ui/main.menu
 	@(cd $(ASSETS_DIR) && zip -r data-$(VERSION).pk3 *)
-	@mv $(ASSETS_DIR)/data-$(VERSION).pk3 $(B)/$(BASEGAME)
-
-else
-$(B)/basemod/data-$(VERSION).pk3: $(ASSETS_DIR)/ui/main.menu
-	@(cd $(ASSETS_DIR) && zip -r data-$(VERSION).pk3 *)
-	@mv $(ASSETS_DIR)/data-$(VERSION).pk3 $(B)/basemod
-endif
+	@mv $(ASSETS_DIR)/data-$(VERSION).pk3 $(B)/$(BASEMOD)
 endif
 
 #############################################################################
@@ -3001,13 +2940,13 @@ $(B)/$(BASEGAME)/cgame/%.asm: $(CGDIR)/%.c $(Q3LCC)
 	$(DO_CGAME_Q3LCC)
 
 # CGAME (1.1 COMPATIBLE)
-#$(B)/$(BASEGAME)_11/cgame/bg_%.o: $(GDIR)/bg_%.c
+#$(B)/$(BASEMOD)_11/cgame/bg_%.o: $(GDIR)/bg_%.c
 #	$(DO_CGAME_CC_11)
 #
-#$(B)/$(BASEGAME)_11/cgame/ui_%.o: $(UIDIR)/ui_%.c
+#$(B)/$(BASEMOD)_11/cgame/ui_%.o: $(UIDIR)/ui_%.c
 #	$(DO_CGAME_CC_11)
 #
-#$(B)/$(BASEGAME)_11/cgame/%.o: $(CGDIR)/%.c
+#$(B)/$(BASEMOD)_11/cgame/%.o: $(CGDIR)/%.c
 #	$(DO_CGAME_CC_11)
 
 $(B)/$(BASEGAME)/11/cgame/%.asm: $(CGDIR)/%.c $(Q3LCC)
@@ -3101,198 +3040,198 @@ ifneq ($(B),)
   -include $(OBJ_D_FILES) $(TOOLSOBJ_D_FILES)
 endif
 
-ifeq ($(B),$(BR))
 ifneq ($(BUILD_GAME_QVM),0)
 ifneq ($(BUILD_GAME_QVM_11),0)
 ifneq ($(BUILD_DATA_PK3),0)
+ifneq ($(BASEMOD), basemod)
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/data-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 else
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 endif
 else
-ifneq ($(BUILD_DATA_PK3),0)
+ifneq ($(BASEMOD), basemod)
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/data-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 else
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/vms-gpp-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
+endif
+endif
+else
+ifneq ($(BUILD_DATA_PK3),0)
+ifneq ($(BASEMOD), basemod)
+.PHONY: all clean clean2 clean-debug clean-release \
+	debug default dist distclean makedirs release targets \
+	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
+	$(B).zip
+else
+.PHONY: all clean clean2 clean-debug clean-release \
+	debug default dist distclean makedirs release targets \
+	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
+	$(B).zip
+endif
+else
+ifneq ($(BASEMOD), basemod)
+.PHONY: all clean clean2 clean-debug clean-release \
+	debug default dist distclean makedirs release targets \
+	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
+	$(B).zip
+else
+.PHONY: all clean clean2 clean-debug clean-release \
+	debug default dist distclean makedirs release targets \
+	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
+	$(B)/$(BASEMOD)/vms-gpp-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
+	$(B).zip
+endif
 endif
 endif
 else
 ifneq ($(BUILD_GAME_QVM_11),0)
 ifneq ($(BUILD_DATA_PK3),0)
+ifneq ($(BASEMOD), basemod)
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/data-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 else
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/vms-1.1-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
+endif
+else
+ifneq ($(BASEMOD), basemod)
+.PHONY: all clean clean2 clean-debug clean-release \
+	debug default dist distclean makedirs release targets \
+	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
+	$(B).zip
+else
+.PHONY: all clean clean2 clean-debug clean-release \
+	debug default dist distclean makedirs release targets \
+	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
+	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
+	$(B)/$(BASEMOD)/vms-1.1-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
+	$(B).zip
+endif
 endif
 else
 ifneq ($(BUILD_DATA_PK3),0)
+ifneq ($(BASEMOD), basemod)
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/data-$(VERSION).pk3 \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 else
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/$(BASEGAME)/core-cgame$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-game$(SHLIBNAME) \
-	$(B)/$(BASEGAME)/core-ui$(SHLIBNAME) \
-	$(B).zip
-endif
-endif
-endif
-
-else
-ifneq ($(BUILD_GAME_QVM),0)
-ifneq ($(BUILD_GAME_QVM_11),0)
-ifneq ($(BUILD_DATA_PK3),0)
-.PHONY: all clean clean2 clean-debug clean-release \
-	debug default dist distclean makedirs release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/data-$(VERSION).pk3 \
-	$(B)/basemod/vms-1.1-$(VERSION).pk3 \
-	$(B)/basemod/vms-gpp-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
-	$(B).zip
-else
-.PHONY: all clean clean2 clean-debug clean-release \
-	debug default dist distclean makedirs release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/vms-1.1-$(VERSION).pk3 \
-	$(B)/basemod/vms-gpp-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
-	$(B).zip
-endif
-ifneq ($(BUILD_DATA_PK3),0)
-.PHONY: all clean clean2 clean-debug clean-release \
-	debug default dist distclean makedirs release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/data-$(VERSION).pk3 \
-	$(B)/basemod/vms-gpp-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
-	$(B).zip
-else
-.PHONY: all clean clean2 clean-debug clean-release \
-	debug default dist distclean makedirs release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/vms-gpp-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
-	$(B).zip
-endif
-endif
-else
-ifneq ($(BUILD_GAME_QVM_11),0)
-ifneq ($(BUILD_DATA_PK3),0)
-.PHONY: all clean clean2 clean-debug clean-release \
-	debug default dist distclean makedirs release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/data-$(VERSION).pk3 \
-	$(B)/basemod/vms-1.1-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
-	$(B).zip
-else
-.PHONY: all clean clean2 clean-debug clean-release \
-	debug default dist distclean makedirs release targets \
-	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
-	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/vms-1.1-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/data-$(VERSION).pk3 \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 endif
 else
-ifneq ($(BUILD_DATA_PK3),0)
+ifneq ($(BASEMOD), basemod)
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/data-$(VERSION).pk3 \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/core-game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 else
 .PHONY: all clean clean2 clean-debug clean-release \
 	debug default dist distclean makedirs release targets \
 	toolsclean toolsclean2 toolsclean-debug toolsclean-release \
 	$(OBJ_D_FILES) $(TOOLSOBJ_D_FILES) $(B)/scripts \
-	$(B)/basemod/cgame$(SHLIBNAME) \
-	$(B)/basemod/game$(SHLIBNAME) \
-	$(B)/basemod/ui$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/cgame$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/game$(SHLIBNAME) \
+	$(B)/$(BASEMOD)/ui$(SHLIBNAME) \
 	$(B).zip
 endif
 endif

--- a/make-macosx-app.sh
+++ b/make-macosx-app.sh
@@ -3,9 +3,9 @@
 # Let's make the user give us a target to work with.
 # architecture is assumed universal if not specified, and is optional.
 # if arch is defined, it we will store the .app bundle in the target arch build directory
-if [ $# == 0 ] || [ $# -gt 2 ]; then
-	echo "Usage:   $0 target <arch>"
-	echo "Example: $0 release x86"
+if [ $# == 0 ] || [ $# -gt 3 ]; then
+	echo "Usage:   $0 target <basemod> <arch>"
+	echo "Example: $0 release basemod x86"
 	echo "Valid targets are:"
 	echo " release"
 	echo " debug"
@@ -33,13 +33,13 @@ fi
 CURRENT_ARCH=""
 
 # validate the architecture if it was specified
-if [ "$2" != "" ]; then
-	if [ "$2" == "x86" ]; then
+if [ "$3" != "" ]; then
+	if [ "$3" == "x86" ]; then
 		CURRENT_ARCH="x86"
-	elif [ "$2" == "x86_64" ]; then
+	elif [ "$3" == "x86_64" ]; then
 		CURRENT_ARCH="x86_64"
 	else
-		echo "Invalid architecture: $2"
+		echo "Invalid architecture: $3"
 		echo "Valid architectures are:"
 		echo " x86"
 		echo " x86_64"
@@ -127,16 +127,14 @@ IOQ3_MP_CGAME_ARCHS=""
 IOQ3_MP_GAME_ARCHS=""
 IOQ3_MP_UI_ARCHS=""
 
-BASEDIR="trem13"
+BASEDIR=$2
 
-if [[ "${TARGET_NAME}" == "release" ]]; then
-	CGAME="core-cgame"
-	GAME="core-game"
-	UI="core-ui"
-else
-	CGAME="cgame"
+CGAME="cgame"
+UI="ui"
+if [[ "${2}" == "basemod" ]]; then
 	GAME="game"
-	UI="ui"
+else
+	GAME="core-game"
 fi
 
 RENDERER_OPENGL="renderer_opengl"
@@ -240,7 +238,7 @@ if [ "${IOQ3_CLIENT_ARCHS}" == "" ]; then
 fi
 
 # set the final application bundle output directory
-if [ "${2}" == "" ]; then
+if [ "${3}" == "" ]; then
 	BUILT_PRODUCTS_DIR="${OBJROOT}/${TARGET_NAME}-macos-universal"
 	if [ ! -d ${BUILT_PRODUCTS_DIR} ]; then
 		mkdir -p ${BUILT_PRODUCTS_DIR} || exit 1;

--- a/misc/make-macosx-ub.sh
+++ b/misc/make-macosx-ub.sh
@@ -91,4 +91,4 @@ echo;echo
 echo
 
 # use the following shell script to build a universal application bundle
-"./make-macosx-app.sh" release
+"./make-macosx-app.sh" release basemod

--- a/misc/make-macosx.sh
+++ b/misc/make-macosx.sh
@@ -81,4 +81,4 @@ NCPU=`sysctl -n hw.ncpu`
 (ARCH=${BUILDARCH} CFLAGS=$ARCH_CFLAGS LDFLAGS=$ARCH_LDFLAGS make -j$NCPU) || exit 1;
 
 # use the following shell script to build an application bundle
-"./make-macosx-app.sh" release ${BUILDARCH}
+"./make-macosx-app.sh" release basemod ${BUILDARCH}

--- a/misc/travis-ci-build.sh
+++ b/misc/travis-ci-build.sh
@@ -5,7 +5,7 @@ failed=0
 
 if [[ $PLATFORM == "darwin" ]]; then
     rm -rf build
-    USE_FREETYPE=0 USE_RESTCLIENT=1 USE_INTERNAL_LUA=1 make -j 2 release || failed=1
+    BASEMOD=trem13 USE_FREETYPE=0 USE_RESTCLIENT=1 USE_INTERNAL_LUA=1 make -j 2 release || failed=1
     ./misc/download-paks.sh
 fi
 

--- a/misc/travis-ci-docker-build.sh
+++ b/misc/travis-ci-docker-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 failed=0
 
-USE_RESTCLIENT=1 USE_INTERNAL_LUA=1 make -j 2 || failed=1
+BASEMOD=trem13 USE_RESTCLIENT=1 USE_INTERNAL_LUA=1 make -j 2 || failed=1
 
 if [[ $failed -eq 1 ]]; then
     echo "Build failure."
@@ -9,4 +9,15 @@ if [[ $failed -eq 1 ]]; then
 fi
 
 ./misc/download-paks.sh
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+P=$(uname | sed -e 's/_.*//' | tr '[:upper:]' '[:lower:]' | sed -e 's/\//_/g')
+PLATFORM=${PLATFORM:-$P}
+for dir in ${REPO_ROOT}/build/*; do
+  if [[ $PLATFORM != "darwin" ]]; then
+      zip -d ${REPO_ROOT}/build/$(basename $dir).zip "trem13_11/vm/*"
+      zip -d ${REPO_ROOT}/build/$(basename $dir).zip "trem13_11/vm"
+      zip -d ${REPO_ROOT}/build/$(basename $dir).zip "trem13_11/*"
+      zip -d ${REPO_ROOT}/build/$(basename $dir).zip "trem13_11"
+  fi
+done
 chmod -R ugo+rw build

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -736,6 +736,9 @@ static char demoName[MAX_QPATH];  // compiler bug workaround
 
 static void CL_Record_f(void)
 {
+    char check_demo_name1[MAX_QPATH];
+    char check_demo_name2[MAX_QPATH];
+    char check_demo_name3[MAX_QPATH];
     char name[MAX_OSPATH];
     byte bufData[MAX_MSGLEN];
     msg_t buf;
@@ -774,7 +777,24 @@ static void CL_Record_f(void)
     if (Cmd_Argc() == 2)
     {
         const char *s = Cmd_Argv(1);
+        
         Q_strncpyz(demoName, s, sizeof(demoName));
+        Com_sprintf(
+            check_demo_name1, sizeof(check_demo_name1),
+            "demos/%s.%s71", demoName, DEMOEXT);
+        Com_sprintf(
+            check_demo_name2, sizeof(check_demo_name2),
+            "demos/%s.%s69", demoName, DEMOEXT);
+        Com_sprintf(
+            check_demo_name3, sizeof(check_demo_name3),
+            "demos/%s.%s70", demoName, DEMOEXT);
+        if (
+            FS_FileExistsInBaseGame(check_demo_name1) ||
+            FS_FileExistsInBaseGame(check_demo_name2) ||
+            FS_FileExistsInBaseGame(check_demo_name3)) {
+            Com_Printf(S_COLOR_RED "Demo name already exists, pick another name.\n" S_COLOR_WHITE);
+            return;
+        }
         Com_sprintf(
           name, sizeof(name),
           "demos/%s.%s%d", demoName, DEMOEXT,
@@ -789,9 +809,29 @@ static void CL_Record_f(void)
         for (number = 0; number <= 9999; number++)
         {
             CL_DemoFilename(number, demoName, sizeof(demoName));
-            Com_sprintf(name, sizeof(name), "demos/%s.%s%d", demoName, DEMOEXT, PROTOCOL_VERSION);
 
-            if (!FS_FileExists(name)) break;  // file doesn't exist
+            Com_sprintf(
+                check_demo_name1, sizeof(check_demo_name1),
+                "demos/%s.%s71", demoName, DEMOEXT);
+            Com_sprintf(
+                check_demo_name2, sizeof(check_demo_name2),
+                "demos/%s.%s69", demoName, DEMOEXT);
+            Com_sprintf(
+                check_demo_name3, sizeof(check_demo_name3),
+                "demos/%s.%s70", demoName, DEMOEXT);
+
+            if (
+                !FS_FileExistsInBaseGame(check_demo_name1) &&
+                !FS_FileExistsInBaseGame(check_demo_name2) &&
+                !FS_FileExistsInBaseGame(check_demo_name3)) {
+                // file doesn't exist, so use this name
+                Com_sprintf(
+                  name, sizeof(name),
+                  "demos/%s.%s%d", demoName, DEMOEXT,
+                    (clc.netchan.alternateProtocol == 0 ?
+                      PROTOCOL_VERSION : clc.netchan.alternateProtocol == 1 ? 70 : 69));
+                break;
+            }
         }
     }
 

--- a/src/filesystem/fs_fileio.cpp
+++ b/src/filesystem/fs_fileio.cpp
@@ -341,6 +341,15 @@ qboolean FS_FileExists(const char *file)
     return FS_FileInPathExists(path);
 }
 
+static const char *fs_tremulous_write_mod_location(fs_handle_owner_t owner);
+qboolean FS_FileExistsInBaseGame(const char *file)
+{
+    char path[FS_MAX_PATH];
+    if (!fs_generate_path_sourcedir(0, fs_tremulous_write_mod_location(FS_HANDLEOWNER_SYSTEM), file, 0, FS_ALLOW_DIRECTORIES, path, sizeof(path)))
+        return qfalse;
+    return FS_FileInPathExists(path);
+}
+
 /* ******************************************************************************** */
 // File read cache
 /* ******************************************************************************** */

--- a/src/filesystem/fspublic.h
+++ b/src/filesystem/fspublic.h
@@ -258,6 +258,7 @@ DEF_LOCAL( void fs_delete_file(const char *path) )
 DEF_PUBLIC( void FS_HomeRemove( const char *homePath ) )
 DEF_LOCAL( qboolean FS_FileInPathExists(const char *testpath) )
 DEF_PUBLIC( qboolean FS_FileExists(const char *file) )
+DEF_PUBLIC( qboolean FS_FileExistsInBaseGame(const char *file) )
 
 // File read cache
 DEF_PUBLIC( void fs_cache_initialize(void) )


### PR DESCRIPTION
- change the naming of the core-cgame and core-ui dynamic libraries back to simply cgame and ui.
- have the generated 1.1 client compatable QVMs placed in basemod_11.
- fix the demo record to take into consideration all supported protocols when a demo name isn't specified.
- have local builds use the basemod file, and have travis builds use the trem13 folder for generated files.